### PR TITLE
Fix cours_bitcoin_realtime crashing in integration environment

### DIFF
--- a/kafka_to_elastic/cours_bitcoin_realtime/src/main/java/bigcoin/App.java
+++ b/kafka_to_elastic/cours_bitcoin_realtime/src/main/java/bigcoin/App.java
@@ -50,9 +50,6 @@ public class App
         if(System.getenv("ES_HOST") != null) {
             host_es = System.getenv("ES_HOST");
         }
-        if(System.getenv("ES_PORT") != null) {
-            port_es = Integer.parseInt(System.getenv("ES_PORT"));
-        }
 
         // Initialize Spark config and context
         SparkConf sparkConf = new SparkConf().setAppName("SparkStreamKafka").setMaster("local[2]");


### PR DESCRIPTION
The port used for elasticsearch isn't the http one so we mustn't get the one for env vars.